### PR TITLE
Queue complex objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,18 @@
 GIT
   remote: https://github.com/marcosgz/esse.git
-  revision: ebbe8016650c2d090873a8799e8b127a39a592bf
+  revision: 7d8fef8646a2f6acc3bfa475f351cfcd7d88fe17
   branch: main
   specs:
-    esse (0.2.6)
+    esse (0.3.4)
       multi_json
       thor (>= 0.19)
 
 PATH
   remote: .
   specs:
-    esse-redis_storage (0.0.2)
-      esse (>= 0.2.4)
+    esse-redis_storage (0.1.0)
+      esse (>= 0.3.2)
+      multi_json (>= 1.0.0)
       redis (>= 4.0.0)
 
 GEM

--- a/esse-redis_storage.gemspec
+++ b/esse-redis_storage.gemspec
@@ -29,8 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "esse", ">= 0.2.4"
+  spec.add_dependency "esse", ">= 0.3.2"
   spec.add_dependency "redis", ">= 4.0.0"
+  spec.add_dependency "multi_json", ">= 1.0.0"
   spec.add_development_dependency "connection_pool"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rspec"

--- a/lib/esse/redis_storage.rb
+++ b/lib/esse/redis_storage.rb
@@ -2,6 +2,7 @@
 
 require "esse"
 require "redis"
+require "multi_json"
 require "forwardable"
 require "securerandom"
 

--- a/lib/esse/redis_storage/version.rb
+++ b/lib/esse/redis_storage/version.rb
@@ -2,6 +2,6 @@
 
 module Esse
   module RedisStorage
-    VERSION = "0.0.2"
+    VERSION = "0.1.0"
   end
 end

--- a/spec/esse/redis_storage/queue_spec.rb
+++ b/spec/esse/redis_storage/queue_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Esse::RedisStorage::Queue do
       expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq("1,2")
     end
 
+    it "enqueues the payload using array of objects" do
+      batch_id = queue.enqueue(values: [{id: 1}, {id: 2}])
+      expect(batch_id).to be_a(String)
+      expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq(%({"id":1},{"id":2}))
+    end
+
     it "does not enqueue empty values" do
       batch_id = queue.enqueue(values: [])
       expect(batch_id).to be_nil

--- a/spec/esse/redis_storage/queue_spec.rb
+++ b/spec/esse/redis_storage/queue_spec.rb
@@ -40,19 +40,19 @@ RSpec.describe Esse::RedisStorage::Queue do
     it "generates a random id and enqueues the payload" do
       batch_id = queue.enqueue(values: [1, 2])
       expect(batch_id).to be_a(String)
-      expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq("1,2")
+      expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq("[1,2]")
     end
 
     it "enqueues the payload with the given id" do
       batch_id = queue.enqueue(id: "my-id", values: [1, 2])
       expect(batch_id).to eq("my-id")
-      expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq("1,2")
+      expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq("[1,2]")
     end
 
     it "enqueues the payload using array of objects" do
       batch_id = queue.enqueue(values: [{id: 1}, {id: 2}])
       expect(batch_id).to be_a(String)
-      expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq(%({"id":1},{"id":2}))
+      expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq(%([{"id":1},{"id":2}]))
     end
 
     it "does not enqueue empty values" do
@@ -74,7 +74,7 @@ RSpec.describe Esse::RedisStorage::Queue do
     end
 
     it "fetches a batch" do
-      Esse.config.redis.hset("esse:queue:my-queue", "my-id", "1,2")
+      Esse.config.redis.hset("esse:queue:my-queue", "my-id", '["1","2"]')
       queue.fetch("my-id") do |values|
         expect(values).to eq(%w[1 2])
       end
@@ -88,13 +88,13 @@ RSpec.describe Esse::RedisStorage::Queue do
     end
 
     it "does not remove the batch if yield raises an error" do
-      Esse.config.redis.hset("esse:queue:my-queue", "my-id", "1,2")
+      Esse.config.redis.hset("esse:queue:my-queue", "my-id", "[1,2]")
       expect do
         queue.fetch("my-id") do |_values|
           raise "error"
         end
       end.to raise_error("error")
-      expect(Esse.config.redis.hget("esse:queue:my-queue", "my-id")).to eq("1,2")
+      expect(Esse.config.redis.hget("esse:queue:my-queue", "my-id")).to eq("[1,2]")
     end
   end
 
@@ -106,12 +106,12 @@ RSpec.describe Esse::RedisStorage::Queue do
     end
 
     it "iterates over each batch" do
-      Esse.config.redis.hset("esse:queue:my-queue", "my-id-1", "1,2")
-      Esse.config.redis.hset("esse:queue:my-queue", "my-id-2", "3,4")
+      Esse.config.redis.hset("esse:queue:my-queue", "my-id-1", "[1,2]")
+      Esse.config.redis.hset("esse:queue:my-queue", "my-id-2", "[3,4]")
 
       expect { |b| queue.each(&b) }.to yield_successive_args(
-        ["my-id-1", %w[1 2]],
-        ["my-id-2", %w[3 4]]
+        ["my-id-1", [1, 2]],
+        ["my-id-2", [3, 4]]
       )
 
       expect(queue.size).to eq(2)
@@ -126,7 +126,7 @@ RSpec.describe Esse::RedisStorage::Queue do
     end
 
     it "deletes a batch" do
-      Esse.config.redis.hset("esse:queue:my-queue", "my-id", "1,2")
+      Esse.config.redis.hset("esse:queue:my-queue", "my-id", "[1,2]")
       queue.delete("my-id")
       expect(Esse.config.redis.hget("esse:queue:my-queue", "my-id")).to be_nil
     end


### PR DESCRIPTION
Adjusting queue to allow to enqueue complex objects like Ruby hash and also preserve the primitive type.