### PR TITLE
feat: Add TTL option to the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 - 2024-08-06
+* Add TTL to the enqueued items in the queue.
+* Included current time in the rand batch id to be more human readable.
+
+## 0.1.0 - 2024-07-31
+* Adjusting queue to allow to enqueue complex objects like Ruby hash and also preserve the primitive type.
+
 ## 0.0.2 - 2024-07-18
 * The `Esse::RedisStorage::Queue.for` method now support both `repo:` and `attribute_name:` options.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    esse-redis_storage (0.1.0)
+    esse-redis_storage (0.1.1)
       esse (>= 0.3.2)
       multi_json (>= 1.0.0)
       redis (>= 4.0.0)

--- a/lib/esse/redis_storage/version.rb
+++ b/lib/esse/redis_storage/version.rb
@@ -2,6 +2,6 @@
 
 module Esse
   module RedisStorage
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/spec/esse/redis_storage/queue_spec.rb
+++ b/spec/esse/redis_storage/queue_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe Esse::RedisStorage::Queue do
       expect(Esse.config.redis.hget("esse:queue:my-queue", batch_id)).to eq(%([{"id":1},{"id":2}]))
     end
 
+    it "accepts a ttl" do
+      batch_id = queue.enqueue(values: [1, 2], ttl: 10)
+      expect(batch_id).to be_a(String)
+      expect(Esse.config.redis.ttl("esse:queue:my-queue")).to be_within(1).of(10)
+    end
+
     it "does not enqueue empty values" do
       batch_id = queue.enqueue(values: [])
       expect(batch_id).to be_nil


### PR DESCRIPTION
* Add TTL to the enqueued items in the queue.
* Included current time in the rand batch id to be more human readable.

```ruby
batch_id = Esse::RedisStorage::Queue.for(repo: UsersIndex::User).enqueue(values: (1..10).to_a, ttl: 604800)
```