### PR TITLE
feat: add redis_queue_ttl to config as a global TTL of redis queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 - 2024-08-08
+* Add `redis_queue_ttl` configuration option to the `Esse::Config` class.
+
 ## 0.1.1 - 2024-08-06
 * Add TTL to the enqueued items in the queue.
 * Included current time in the rand batch id to be more human readable.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    esse-redis_storage (0.1.1)
+    esse-redis_storage (0.1.2)
       esse (>= 0.3.2)
       multi_json (>= 1.0.0)
       redis (>= 4.0.0)

--- a/lib/esse/redis_storage/config.rb
+++ b/lib/esse/redis_storage/config.rb
@@ -8,7 +8,7 @@ module Esse
       end
 
       module InstanceMethods
-        attr_accessor :redis
+        attr_accessor :redis, :redis_queue_ttl
 
         def redis_pool
           @redis_pool ||= Esse::RedisStorage::Pool.new(redis)

--- a/lib/esse/redis_storage/queue.rb
+++ b/lib/esse/redis_storage/queue.rb
@@ -31,6 +31,7 @@ module Esse
       def enqueue(id: nil, values: [], ttl: nil)
         return if values.nil? || values.empty?
 
+        ttl ||= Esse.config.redis_queue_ttl
         values = ::Esse::ArrayUtils.wrap(values)
         batch_id = id || self.class.batch_id
         with do |conn|

--- a/lib/esse/redis_storage/version.rb
+++ b/lib/esse/redis_storage/version.rb
@@ -2,6 +2,6 @@
 
 module Esse
   module RedisStorage
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/esse/redis_storage/config_spec.rb
+++ b/spec/esse/redis_storage/config_spec.rb
@@ -17,4 +17,11 @@ RSpec.describe Esse::RedisStorage::Config do
       expect(Esse.config.redis).to eq(redis)
     end
   end
+
+  describe "#redis_queue_ttl" do
+    it "returns the given queue_ttl" do
+      Esse.config.redis_queue_ttl = 10
+      expect(Esse.config.redis_queue_ttl).to eq(10)
+    end
+  end
 end

--- a/spec/esse/redis_storage/queue_spec.rb
+++ b/spec/esse/redis_storage/queue_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe Esse::RedisStorage::Queue do
       expect(Esse.config.redis.ttl("esse:queue:my-queue")).to be_within(1).of(10)
     end
 
+    it "uses the default ttl from config" do
+      Esse.config.redis_queue_ttl = 20
+      batch_id = queue.enqueue(values: [1, 2])
+      expect(batch_id).to be_a(String)
+      expect(Esse.config.redis.ttl("esse:queue:my-queue")).to be_within(1).of(20)
+      Esse.config.redis_queue_ttl = nil
+    end
+
     it "does not enqueue empty values" do
       batch_id = queue.enqueue(values: [])
       expect(batch_id).to be_nil


### PR DESCRIPTION
Add global `redis_queue_ttl` to the config. It will allow to define a global TTL value to all objects enqueued.
